### PR TITLE
feat: sign Docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      attestations: write
     steps:
 
       - name: Checkout
@@ -38,10 +39,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
+      - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,6 +74,13 @@ docker_manifests:
       - ghcr.io/firebolt-db/mcp-server:{{ .Version }}-amd64
       - ghcr.io/firebolt-db/mcp-server:{{ .Version }}-arm64v8
 
+docker_signs:
+  - artifacts: all
+    args:
+      - "sign"
+      - "${artifact}@${digest}"
+      - "--yes"
+
 release:
   replace_existing_artifacts: true
   mode: keep-existing


### PR DESCRIPTION
This PR adds support for keyless signing using [Sigstore’s identity-based workflow](https://docs.sigstore.dev/cosign/signing/overview/).

Instead of managing long-lived signing keys, Cosign now uses ephemeral keys bound to OpenID Connect (OIDC) identities, verified by Fulcio, and recorded in the Rekor transparency log. This provides a secure, auditable way to sign artifacts without persistent private keys.

Signature can be verified with:

```
cosign verify \
  --certificate-identity "https://github.com/firebolt-db/mcp-server/.github/workflows/release.yaml@refs/heads/main" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  ghcr.io/firebolt-db/mcp-server:TAG
```