### PR TITLE
fix(docs): correct typo in test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,5 +182,5 @@ task mod
 task build
 
 # Run the tests
-tast test
+task test
 ```


### PR DESCRIPTION
Fixed a typo in the README.md file where "tast test" was replaced with "task test".

This ensures clarity and prevents confusion for users following the instructions.