### PR TITLE
feat: add support for text-only content in MCP tools

### DIFF
--- a/cmd/firebolt-mcp-server/main.go
+++ b/cmd/firebolt-mcp-server/main.go
@@ -63,6 +63,13 @@ func main() {
 				Usage:    "SSE transport listen address (used only if transport is set to sse)",
 				Sources:  cli.EnvVars("FIREBOLT_MCP_TRANSPORT_SSE_LISTEN_ADDRESS"),
 			},
+			&cli.BoolFlag{
+				Name:     "disable-resources",
+				Category: "MCP Transport",
+				Value:    false,
+				Usage:    "Return text content instead of embedded resources (for clients that do not support resources)",
+				Sources:  cli.EnvVars("FIREBOLT_MCP_DISABLE_RESOURCES"),
+			},
 			&cli.StringFlag{
 				Name:     "client-id",
 				Category: "Firebolt Authentication",
@@ -123,6 +130,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 
 	// Initialize MCP server
 	docsProof := generateRandomSecret()
+	disableResources := cmd.Bool("disable-resources")
 	resourceDocs := resources.NewDocs(fireboltdocs.FS, docsProof)
 	resourceAccounts := resources.NewAccounts(discoveryClient)
 	resourceDatabases := resources.NewDatabases(dbPool)
@@ -133,8 +141,8 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		cmd.String("transport"),
 		cmd.String("transport-sse-listen-address"),
 		[]server.Tool{
-			tools.NewConnect(resourceAccounts, resourceDatabases, resourceEngines, docsProof),
-			tools.NewDocs(resourceDocs),
+			tools.NewConnect(resourceAccounts, resourceDatabases, resourceEngines, docsProof, disableResources),
+			tools.NewDocs(resourceDocs, disableResources),
 			tools.NewQuery(dbPool),
 		},
 		[]server.Prompt{

--- a/pkg/tools/connect.go
+++ b/pkg/tools/connect.go
@@ -44,6 +44,7 @@ type Connect struct {
 	databasesFetcher DatabaseResourcesFetcher // Fetches database resources
 	enginesFetcher   EngineResourcesFetcher   // Fetches engine resources
 	docsProof        string                   // Shared with the docs resources
+	disableResources bool                     // Return text content instead of embedded resources
 }
 
 // NewConnect creates a new instance of the Connect tool with the provided resource fetchers.
@@ -53,12 +54,14 @@ func NewConnect(
 	databasesFetcher DatabaseResourcesFetcher,
 	enginesFetcher EngineResourcesFetcher,
 	docsProof string,
+	disableResources bool,
 ) *Connect {
 	return &Connect{
 		accountsFetcher:  accountsFetcher,
 		databasesFetcher: databasesFetcher,
 		enginesFetcher:   enginesFetcher,
 		docsProof:        docsProof,
+		disableResources: disableResources,
 	}
 }
 
@@ -178,7 +181,7 @@ func (t *Connect) Handler(ctx context.Context, request mcp.CallToolRequest) (*mc
 	return &mcp.CallToolResult{
 		Result: mcp.Result{},
 		Content: itertools.Map(results, func(i mcp.ResourceContents) mcp.Content {
-			return mcp.NewEmbeddedResource(i)
+			return textOrResourceContent(t.disableResources, i)
 		}),
 		IsError: false,
 	}, nil

--- a/pkg/tools/docs.go
+++ b/pkg/tools/docs.go
@@ -21,14 +21,16 @@ type DocsResourcesFetcher interface {
 // Docs represents a tool for fetching and returning Firebolt documentation.
 // It provides access to documentation articles that explain Firebolt concepts and functionality.
 type Docs struct {
-	docsFetcher DocsResourcesFetcher // Fetches documentation resources
+	docsFetcher      DocsResourcesFetcher // Fetches documentation resources
+	disableResources bool                 // Return text content instead of embedded resources
 }
 
 // NewDocs creates a new instance of the Docs tool with the provided documentation fetcher.
 // It requires an implementation for fetching documentation articles.
-func NewDocs(docsFetcher DocsResourcesFetcher) *Docs {
+func NewDocs(docsFetcher DocsResourcesFetcher, disableResources bool) *Docs {
 	return &Docs{
-		docsFetcher: docsFetcher,
+		docsFetcher:      docsFetcher,
+		disableResources: disableResources,
 	}
 }
 
@@ -103,7 +105,7 @@ func (t *Docs) Handler(ctx context.Context, request mcp.CallToolRequest) (*mcp.C
 	return &mcp.CallToolResult{
 		Result: mcp.Result{},
 		Content: itertools.Map(results, func(i mcp.ResourceContents) mcp.Content {
-			return mcp.NewEmbeddedResource(i)
+			return textOrResourceContent(t.disableResources, i)
 		}),
 		IsError: false,
 	}, nil

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -1,0 +1,16 @@
+package tools
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+// textOrResourceContent returns a text content if disableResources is true, otherwise returns an embedded resource.
+func textOrResourceContent(disableResources bool, i mcp.ResourceContents) mcp.Content {
+
+	if disableResources {
+		textResource, ok := i.(mcp.TextResourceContents)
+		if ok {
+			return mcp.NewTextContent(textResource.Text)
+		}
+	}
+
+	return mcp.NewEmbeddedResource(i)
+}


### PR DESCRIPTION
Cursor removed support for MCP Resources in version 0.46.9+, breaking compatibility with Firebolt’s MCP server which relied heavily on resource embedding.

To restore functionality, introduced the `--disable-resources` CLI flag that allows `Docs` and `Connect` tools to return plain text responses instead of embedded resources.